### PR TITLE
support jdk15(gradle runtmie) and prepare Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build/
 
 .idea/
 *.iml
+classpath.cmd

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+define CMD_ECHO_OFF
+@echo off
+
+endef
+export CMD_ECHO_OFF
+
+TARGET_SDK=34
+
+classpath.cmd:
+	@echo "$${CMD_ECHO_OFF}$${ANDROID_HOME}\\platforms\\android-$(TARGET_SDK)\\android.jar" > classpath.cmd
+
+.PHONY: clean
+clean:
+	rm classpath.cmd

--- a/annotation/build.gradle
+++ b/annotation/build.gradle
@@ -1,2 +1,7 @@
 apply plugin: 'java-library'
 apply plugin: "com.vanniktech.maven.publish"
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -37,14 +37,14 @@ COMMONS_IO_VERSION      = 2.6
 KOMPILE_TESTING_VERSION = 0.1.4
 
 # Android configuration
-COMPILE_SDK_VERSION     = android-29
-TARGET_SDK_VERSION      = 29
-MIN_SDK_VERSION         = 14
-SAMPLE_MIN_SDK_VERSION  = 16
+COMPILE_SDK_VERSION     = android-34
+TARGET_SDK_VERSION      = 34
+MIN_SDK_VERSION         = 21
+SAMPLE_MIN_SDK_VERSION  = 21
 
 # Gradle parameters
 org.gradle.daemon       = true
-org.gradle.jvmargs      = -XX:MaxPermSize=1024m -XX:+CMSClassUnloadingEnabled -XX:+HeapDumpOnOutOfMemoryError -Xmx2048m
+org.gradle.jvmargs      = -Xmx2048m
 
 # AndroidX
 android.useAndroidX     = true

--- a/ktx-sample/src/main/AndroidManifest.xml
+++ b/ktx-sample/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
         tools:ignore="GoogleAppIndexingWarning">
         <activity
             android:name=".MainActivity"
+            android:exported="true"
             android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -9,8 +9,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_6
-        targetCompatibility JavaVersion.VERSION_1_6
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
 
     packagingOptions {

--- a/lint/build.gradle
+++ b/lint/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'java'
 apply plugin: 'kotlin'
 
-targetCompatibility = JavaVersion.VERSION_1_6
-sourceCompatibility = JavaVersion.VERSION_1_6
+targetCompatibility = JavaVersion.VERSION_1_8
+sourceCompatibility = JavaVersion.VERSION_1_8
 
 configurations {
     lintChecks

--- a/processor/build.gradle
+++ b/processor/build.gradle
@@ -31,7 +31,6 @@ dependencies {
     testCompileAar project(path: ":library", configuration: "default")
 
     testImplementation androidJar()
-    testImplementation files(Jvm.current().getToolsJar())
     testImplementation "junit:junit:$JUNIT_VERSION"
     testImplementation "org.mockito:mockito-core:$MOCKITO_VERSION"
     testImplementation "com.google.testing.compile:compile-testing:$COMPILE_TESTING_VERSION"

--- a/processor/src/test/java/permissions/dispatcher/processor/base/AndroidAwareClassLoader.java
+++ b/processor/src/test/java/permissions/dispatcher/processor/base/AndroidAwareClassLoader.java
@@ -35,9 +35,7 @@ final class AndroidAwareClassLoader {
                     .stream()
                     .map(AndroidAwareClassLoader::unsafeToURL)
                     .toArray(URL[]::new);
-
             return new URLClassLoader(urls, ClassLoader.getSystemClassLoader());
-
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
         tools:ignore="GoogleAppIndexingWarning">
         <activity
             android:name=".MainActivity"
+            android:exported="true"
             android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />


### PR DESCRIPTION
GradleのランタイムをJDK15に更新｡
テストで依存しているClassLoaderがおそらく Java8だと getSystemClassLoaderでURLClassLoaderが取得できていたのがそうでなくなっているから､軒並み動かなくなってるけど､sampleアプリで動作チェックは可能

./gradlew :ktx-sample:build -x test でビルド